### PR TITLE
feat: add development CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,20 @@ Initial monorepo scaffolding for the Tare data orchestration framework.  The lay
 
 ## Development
 
-### Python GraphQL API
+### Unified development environment
+
+Spin up all services with a single command:
+
+```bash
+uv run tare dev
+```
+
+This starts Redis and Postgres via Docker, runs the GraphQL API server, and
+launches the React development server. Stop with `CTRL+C`.
+
+### Individual services
+
+#### Python GraphQL API
 
 ```bash
 # Install dependencies for the GraphQL package
@@ -30,7 +43,7 @@ uv run --package tare-graphql uvicorn tare_graphql.main:app --reload
 uv run --package tare-graphql pytest python_modules/tare-graphql/tests -q
 ```
 
-### UI
+#### UI
 
 ```bash
 npm install --prefix js_modules/tare-ui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: tare
+      POSTGRES_PASSWORD: tare
+      POSTGRES_DB: tare
+    ports:
+      - "5432:5432"

--- a/python_modules/tare/cli.py
+++ b/python_modules/tare/cli.py
@@ -1,0 +1,70 @@
+"""Tare command line interface."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import List
+
+import typer
+
+app = typer.Typer(help="Utilities for developing Tare")
+
+
+def _spawn(cmd: List[str], cwd: Path | None = None) -> subprocess.Popen:
+    """Spawn a subprocess inheriting STDIO."""
+    return subprocess.Popen(cmd, cwd=cwd)
+
+
+@app.command()
+def dev() -> None:
+    """Start the local development environment.
+
+    This command boots supporting services via Docker, then starts the
+    GraphQL API server and the React development server. Processes run until
+    interrupted with CTRL+C.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    ui_path = repo_root / "js_modules" / "tare-ui"
+
+    typer.echo("Starting Docker services...")
+    subprocess.run(["docker", "compose", "up", "-d"], cwd=repo_root, check=False)
+
+    typer.echo("Installing UI dependencies...")
+    subprocess.run(["npm", "install"], cwd=ui_path, check=False)
+
+    typer.echo("Starting GraphQL API server...")
+    api_proc = _spawn(
+        [
+            "uv",
+            "run",
+            "--package",
+            "tare-graphql",
+            "uvicorn",
+            "tare_graphql.main:app",
+            "--reload",
+        ],
+        cwd=repo_root,
+    )
+
+    typer.echo("Starting UI dev server...")
+    ui_proc = _spawn(["npm", "run", "dev"], cwd=ui_path)
+
+    processes = [api_proc, ui_proc]
+
+    try:
+        for proc in processes:
+            proc.wait()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for proc in processes:
+            if proc.poll() is None:
+                proc.terminate()
+
+        typer.echo("Shutting down Docker services...")
+        subprocess.run(
+            ["docker", "compose", "down"], cwd=repo_root, check=False
+        )
+

--- a/python_modules/tare/pyproject.toml
+++ b/python_modules/tare/pyproject.toml
@@ -2,7 +2,12 @@
 name = "tare"
 version = "0.1.0"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "typer",
+]
+
+[project.scripts]
+tare = "tare.cli:app"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -187,6 +187,27 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -308,6 +329,28 @@ wheels = [
 ]
 
 [[package]]
+name = "rich"
+version = "14.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fe/75/af448d8e52bf1d8fa6a9d089ca6c07ff4453d86c65c145d0a300bb073b9b/rich-14.1.0.tar.gz", hash = "sha256:e497a48b844b0320d45007cdebfeaeed8db2a4f4bcf49f15e455cfc4af11eaa8", size = 224441, upload-time = "2025-07-25T07:32:58.125Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/30/3c4d035596d3cf444529e0b2953ad0466f6049528a879d27534700580395/rich-14.1.0-py3-none-any.whl", hash = "sha256:536f5f1785986d6dbdea3c75205c473f970777b4a0d6c6dd1b696aa05a3fa04f", size = 243368, upload-time = "2025-07-25T07:32:56.73Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -393,6 +436,12 @@ fastapi = [
 name = "tare"
 version = "0.1.0"
 source = { editable = "python_modules/tare" }
+dependencies = [
+    { name = "typer" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "typer" }]
 
 [[package]]
 name = "tare-graphql"
@@ -426,6 +475,21 @@ source = { editable = "python_modules/tare-webserver" }
 name = "tare-workspace"
 version = "0.1.0"
 source = { virtual = "." }
+
+[[package]]
+name = "typer"
+version = "0.17.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/e8/2a73ccf9874ec4c7638f172efc8972ceab13a0e3480b389d6ed822f7a822/typer-0.17.4.tar.gz", hash = "sha256:b77dc07d849312fd2bb5e7f20a7af8985c7ec360c45b051ed5412f64d8dc1580", size = 103734, upload-time = "2025-09-05T18:14:40.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/72/6b3e70d32e89a5cbb6a4513726c1ae8762165b027af569289e19ec08edd8/typer-0.17.4-py3-none-any.whl", hash = "sha256:015534a6edaa450e7007eba705d5c18c3349dcea50a6ad79a5ed530967575824", size = 46643, upload-time = "2025-09-05T18:14:39.166Z" },
+]
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary
- add Typer-based `tare dev` CLI to launch Docker services, GraphQL API, and UI
- document unified dev workflow and provide Docker Compose for Postgres/Redis
- expose `tare` console script via project metadata

## Testing
- `uv run --package tare-graphql pytest python_modules/tare-graphql/tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68c01c707510832fb723da909b9ff8ec